### PR TITLE
chore(workflows): update release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-name: build
+name: ci
 on:
   push:
     branches:
@@ -11,40 +11,36 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.19.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Setup
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+
       - name: Cache go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ matrix.go-version }}-
+
       - name: Download go modules
         run: go mod download
+
       - name: Run go test
         run: make coverage
+
       - name: Run go vet
-        run: go vet ./...
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b $(go env GOPATH)/bin v1.35.2
+        run: make vet
+
       - name: Run golangci-lint
-        run: golangci-lint run
-      - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        if: matrix.go-version == '1.15.x' && startsWith(github.ref, 'refs/tags/')
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+---
+name: release
+on:
+  push:
+    tags:
+      - 'v[0-9].[0-9]+.[0-9]+'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Setup
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,23 +13,13 @@ builds:
       - darwin
       - windows
     goarch:
-      - 386
       - amd64
-    ignore:
-      - goos: darwin
-        goarch: 386
-      - goos: windows
-        goarch: 386
+      - arm64
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format: binary
     files:
       - none*
-    replacements:
-      linux: Linux
-      darwin: Darwin
-      386: i386
-      amd64: x86_64
 release:
   github:
     owner: Bonial-International-GmbH


### PR DESCRIPTION
Notable changes:

- The release step was split off into a dedicated workflow which will run when a tag is pushed.
- Use go1.19 for building now.
- Action versions were bumped to more recent ones.
- Goreleaser was configured to now also provide `arm64` releases. `i386` releases were dropped since nobody needs these.